### PR TITLE
商品出品機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,10 @@ gem 'pry-rails'
 
 # 認証機能実装
 gem 'devise'
+
+# ActiveHash実装
+gem 'active_hash'
+
+# ActiveStorage関連機能実装
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.2.0)
+      activesupport (>= 5.0.0)
     activejob (7.0.6)
       activesupport (= 7.0.6)
       globalid (>= 0.3.6)
@@ -106,10 +108,14 @@ GEM
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
     faker-japanese (0.0.1)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -132,6 +138,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.2)
@@ -233,6 +240,8 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -279,6 +288,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_hash
   bootsnap
   capybara
   debug
@@ -286,8 +296,10 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faker-japanese
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,2 +1,33 @@
 class ItemsController < ApplicationController
+  before_action :move_check, only: [ :new ]
+  
+  def index
+  end
+
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @item = Item.new(newitem_params)
+    if @item.save
+      redirect_to root_path
+    else
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
+  private
+  def newitem_params
+    params.require(:item).permit(
+      :image, :title, :describe, :category_id, :condition_id, :price,
+      :shipping_charge_id, :prefecture_id, :shipping_date_id).merge(user_id: current_user.id)
+  end
+
+  def move_check
+    if !user_signed_in?
+      redirect_to new_user_session_path
+    end
+  end
+  
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "price_calculation"

--- a/app/javascript/price_calculation.js
+++ b/app/javascript/price_calculation.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const inputPrice = document.getElementById('item-price');
+  const addTaxPrice = document.getElementById('add-tax-price');
+  const profitPrice = document.getElementById('profit');
+  const tax = 0.1
+  
+  // 販売手数料及び利益を計算
+  inputPrice.addEventListener('keyup', () => {
+    const itemPrice = Number(inputPrice.value);
+    const taxPrice = itemPrice * tax;
+    const profit = itemPrice - taxPrice;
+    addTaxPrice.innerHTML = Math.floor(taxPrice);
+    profitPrice.innerHTML = Math.floor(profit);
+  })
+})

--- a/app/javascript/price_calculation.js
+++ b/app/javascript/price_calculation.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const itemPrice = Number(inputPrice.value);
     const taxPrice = itemPrice * tax;
     const profit = itemPrice - taxPrice;
-    addTaxPrice.innerHTML = Math.floor(taxPrice);
-    profitPrice.innerHTML = Math.floor(profit);
+    addTaxPrice.innerHTML = Math.floor(taxPrice).toLocaleString();
+    profitPrice.innerHTML = Math.floor(profit).toLocaleString();
   })
 })

--- a/app/models/activehash/category.rb
+++ b/app/models/activehash/category.rb
@@ -1,0 +1,18 @@
+class Category < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: 'レディース' },
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
+    { id: 5, name: 'インテリア・住まい・小物' },
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ボビー・グッズ' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/activehash/condition.rb
+++ b/app/models/activehash/condition.rb
@@ -1,0 +1,14 @@
+class Condition < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '新品・未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' },
+    { id: 7, name: '全体的に状態が悪い' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/activehash/prefecture.rb
+++ b/app/models/activehash/prefecture.rb
@@ -1,0 +1,24 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '---' },
+    {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
+    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
+    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
+    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
+    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
+    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
+    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
+    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
+    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
+    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
+    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
+    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
+    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
+    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
+    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
+    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/activehash/shipping_charge.rb
+++ b/app/models/activehash/shipping_charge.rb
@@ -1,4 +1,4 @@
-class Shipping_charge < ActiveHash::Base
+class ShippingCharge < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い(購入者負担)' },

--- a/app/models/activehash/shipping_charge.rb
+++ b/app/models/activehash/shipping_charge.rb
@@ -1,0 +1,10 @@
+class Shipping_charge < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '着払い(購入者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/activehash/shipping_date.rb
+++ b/app/models/activehash/shipping_date.rb
@@ -1,4 +1,4 @@
-class Shipping_date < ActiveHash::Base
+class ShippingDate < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '1~2日で発送' },

--- a/app/models/activehash/shipping_date.rb
+++ b/app/models/activehash/shipping_date.rb
@@ -1,0 +1,11 @@
+class Shipping_date < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '1~2日で発送' },
+    { id: 3, name: '2~3日で発送' },
+    { id: 4, name: '4~7日で発送' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,41 @@
+class Item < ApplicationRecord
+  # association
+  belongs_to :user
+  # ActiveStorage association
+  has_one_attached :image
+
+  # activehash association
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :prefecture
+  belongs_to :shipping_charge
+  belongs_to :shipping_date
+
+  # set error message
+  error_message_halfwidth = 'is invalid. Input half-width characters'
+  error_message_range = 'is out of setting range'
+  error_message_blank = "can't be blank"
+
+  # 属性が空でないことを検証
+  with_options presence: true do
+    # ActiveStorage
+    validates :image
+    validates :title
+    validates :describe
+    # 属性が指定の範囲内且つ、半角数字のみであることを検証
+    validates :price,
+      numericality: { only_integer: true, message: error_message_halfwidth },
+      inclusion: { in: 300..9_999_999, message: error_message_range }
+  end
+
+  # 属性が1以外であることを検証
+  with_options exclusion: { in: [1], message: error_message_blank } do
+    validates :category_id
+    validates :condition_id
+    validates :shipping_charge_id
+    validates :prefecture_id
+    validates :shipping_date_id
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  # association
+  has_many :items
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -12,8 +15,7 @@ class User < ApplicationRecord
   VALID_PASSWORD_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+\z/.freeze
   VALID_FULLWIDTH_CHAR = /\A[ぁ-んァ-ヶ一-龥々ー]+\z/.freeze
   VALID_FULLWIDTH_CHAR_KANA = /\A[ァ-ヶー]+\z/.freeze
-  
-  
+
   # 仮想カラムpasswordが英数字6文字以上となることを検証
   validates :password, format: { with: VALID_PASSWORD_REGEX, message: error_message_pass }
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -182,7 +182,8 @@
   </div>
   <%# /商品一覧 %>
 </div>
-<%= link_to('#', class: 'purchase-btn') do %>
+
+<%= link_to(new_item_path, data: { turbo: false }, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,3 +1,5 @@
+<script src="price_calculation" data-turbolinks-trackt="reload"></script>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
@@ -5,11 +7,9 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, data: { turbo: false }, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -21,7 +21,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -31,13 +31,13 @@
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :describe, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -99,8 +99,9 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
+        
         <div class="price-content">
           <span>販売手数料 (10%)</span>
           <span>
@@ -136,6 +137,7 @@
       </p>
     </div>
     <%# /注意書き %>
+    
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,8 @@ module Furima39619
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # モデルにサブフォルダを読み込ませるための設定
+    config.autoload_paths += %W(#{config.root}/app/models/activehash)
   end
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "price_calculation", to: "price_calculation.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :show]
+  
+  resources :items
+
 end

--- a/db/migrate/20230801093450_create_items.rb
+++ b/db/migrate/20230801093450_create_items.rb
@@ -1,0 +1,16 @@
+class CreateItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :items do |t|
+      t.string     :title,              null: false
+      t.text       :describe,           null: false
+      t.integer    :category_id,        null: false
+      t.integer    :condition_id,       null: false
+      t.integer    :price,              null: false
+      t.integer    :shipping_charge_id, null: false
+      t.integer    :prefecture_id,      null: false
+      t.integer    :shipping_date_id,   null: false
+      t.references :user,               null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230802061417_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230802061417_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :item do
+    title              {Faker::Lorem.sentence(word_count: 1)}
+    describe           {Faker::Lorem.sentence}
+    category_id        {Faker::Number.between(from: 2, to: 11)}
+    condition_id       {Faker::Number.between(from: 2, to: 7)}
+    shipping_charge_id {Faker::Number.between(from: 2, to: 3)}
+    prefecture_id      {Faker::Number.between(from: 2, to: 48)}
+    shipping_date_id   {Faker::Number.between(from: 2, to: 4)}
+    price              {Faker::Number.between(from: 300, to: 9999999)}
+    association :user
+
+    after(:build) do |item|
+      item.image.attach(io: File.open('public/images/DSC_2419.jpg'), filename: 'DSC_2419.jpg')
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Item, type: :model do
           @item.valid?
           expect(@item.errors.full_messages).to include("Price is out of setting range")
         end
-        it 'ユーザーが紐づいていいなければ登録できない' do
+        it 'ユーザーが紐づいていなければ登録できない' do
           @item.user = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("User must exist")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  before do
+    @item = FactoryBot.build(:item)
+  end
+
+    describe '商品出品' do
+      context '出品できるとき' do
+        # 正常系
+        it '属性が空ではなければ出品できる' do
+          expect(@item).to be_valid
+        end
+      end
+      context '出品できないとき' do
+        # 異常系
+        it '画像が空では登録できない' do
+          @item.image = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Image can't be blank")
+        end
+        it '商品名が空では登録できない' do
+          @item.title = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Title can't be blank")
+        end
+        it '商品の説明が空では登録できない' do
+          @item.describe = ''
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Describe can't be blank")
+        end
+        it 'カテゴリーが「---」では登録できない' do
+          @item.category_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Category can't be blank")
+        end
+        it '商品の状態が「---」では登録できない' do
+          @item.condition_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Condition can't be blank")
+        end
+        it '配送料の負担が「---」では登録できない' do
+          @item.shipping_charge_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Shipping charge can't be blank")
+        end
+        it '発送元の地域が「---」では登録できない' do
+          @item.prefecture_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        end
+        it '発送までの日数が「---」では登録できない' do
+          @item.shipping_date_id = 1
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Shipping date can't be blank")
+        end
+        it '販売価格が空では登録できない' do
+          @item.price = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price can't be blank")
+        end
+        it '販売価格が全角数字では登録できない' do
+          @item.price = '３０００'
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+        end
+        it '販売価格が全角文字では登録できない' do
+          @item.price = 'あいう'
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+        end
+        it '販売価格が半角文字では登録できない' do
+          @item.price = 'char'
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+        end
+        it '販売価格が300より小さい値であれば登録できない' do
+          @item.price = 100
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price is out of setting range")
+        end
+        it '販売価格9999999より大きい値であれば登録できない' do
+          @item.price = 100000000
+          @item.valid?
+          expect(@item.errors.full_messages).to include("Price is out of setting range")
+        end
+      end
+    end
+end
+
+
+
+
+

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Item, type: :model do
           expect(@item.errors.full_messages).to include("Price is out of setting range")
         end
         it 'ユーザーが紐づいていいなければ登録できない' do
-          binding.pry
           @item.user = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("User must exist")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe Item, type: :model do
           @item.valid?
           expect(@item.errors.full_messages).to include("Price is out of setting range")
         end
+        it 'ユーザーが紐づいていいなければ登録できない' do
+          binding.pry
+          @item.user = nil
+          @item.valid?
+          expect(@item.errors.full_messages).to include("User must exist")
+        end
       end
     end
 end


### PR DESCRIPTION
# What
商品を出品し、情報を保存できる機能を実装（下記実装条件より引用）
- 必要な情報を適切に入力して「出品する」ボタンを押すと、商品情報がデータベースに保存されること。
- ログイン状態の場合のみ、商品出品ページへ遷移できること。
- ログアウト状態の場合は、商品出品ページへ遷移しようとすると、ログインページへ遷移すること。
- 各情報の入力および画像をつけることが必須であること。
- カテゴリーは、「---、メンズ、レディース、ベビー・キッズ、インテリア・住まい・小物、本・音楽・ゲーム、おもちゃ・ホビー・グッズ、家電・スマホ・カメラ、スポーツ・レジャー、ハンドメイド、その他」の11項目が表示されること（--- は初期値として設定すること）。
- 商品の状態は、「---、新品・未使用、未使用に近い、目立った傷や汚れなし、やや傷や汚れあり、傷や汚れあり、全体的に状態が悪い」の7項目が表示されること（--- は初期値として設定すること）。
- 配送料の負担は、「---、着払い(購入者負担)、送料込み(出品者負担)」の3項目が表示されること（--- は初期値として設定すること）。
- 発送元の地域は、「---」と47都道府県の合計48項目が表示されること（--- は初期値として設定すること）。
- 発送までの日数は、「---、1～2日で発送、2～3日で発送、4～7日で発送」の4項目が表示されること（--- は初期値として設定すること）。
- 価格は、¥300~¥9,999,999の間のみ保存可能であること。
- 価格は半角数値のみ保存可能であること。
- 入力された価格によって、販売手数料や販売利益の表示が変わること。
- 販売手数料と販売利益は、小数点以下を切り捨てて表示すること。
- 出品が完了したら、トップページに遷移すること。
- エラーハンドリングができること（入力に問題がある状態で「出品する」ボタンが押された場合、情報は保存されず、出品ページに戻りエラーメッセージが表示されること）。
- エラーハンドリングによって出品ページに戻った場合でも、入力済みの項目（商品画像・販売手数料・販売利益以外）は消えないこと。
- エラーハンドリングの際、重複したエラーメッセージが表示されないこと。

# Why
商品出品機能を実装するため。

# 動作確認画面
- ログイン状態の場合は、商品出品ページへ遷移できる動画
https://gyazo.com/c19ba86ecaa543dcb7b9ffe925b5471d
- 価格が入力されると同時に、販売手数料と販売利益が表示される動画
https://gyazo.com/65031530506d0026bffecc6bf001686c
- 必要な情報を適切に入力して「出品する」ボタンを押すと、商品情報がデータベースに保存される動画
https://gyazo.com/c54d10ced945346329dcf390956be0d3
- 入力に問題がある状態で「出品する」ボタンが押された場合、情報は保存されず、出品ページに戻りエラーメッセージが表示される動画
https://gyazo.com/19e4536dda3e71ab3706686eb893dc44
- ログアウト状態の場合は、商品出品ページへ遷移しようとすると、ログインページへ遷移する動画
https://gyazo.com/0cc9512dfaa7f251007b2f78547f208f
- テスト結果の画像
https://gyazo.com/ded9060ae29425b2f9591b86769e643e